### PR TITLE
Add missing await when next is called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ const requestLanguage = (props) => {
     }
 
     setProps(props, ctx, language)
-    next()
+    await next()
   }
 }
 


### PR DESCRIPTION
The await operator is needed when is called to be working with Koa 2.